### PR TITLE
"Unmapping a route leaves the route available in the targeted space f…

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -45,7 +45,6 @@ task :deploy => [:package] do
   sh "cf routes"
   # Unmap and delete temp traffic route:
   sh "cf unmap-route #{scapp_appname}-#{new_version} scapp.io -n #{scapp_appname}-#{new_version}"
-  sh "cf delete-route -f -n #{scapp_appname}-#{new_version} scapp.io"
 
   if old_version.length > 0
     # Unmap traffic from old app:


### PR DESCRIPTION
…or later use."-> therefore do not delete route to assure  the route will be available later on.

see
https://docs.cloudfoundry.org/devguide/deploy-apps/domains-routes.html#delete-route
(cherry picked from commit c8fdd28)